### PR TITLE
To suppress the error, header should use the pcl_conversions in hydro ac...

### DIFF
--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -170,7 +170,9 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
     int count = -1;
     
     //cloud.header.stamp.nsec = g_dFrames++;
-    cloud.header.stamp = ros::Time::now();
+    std_msgs::Header std_header;
+    std_header.stamp = ros::Time::now();
+    cloud.header = pcl_conversions::toPCL(std_header);
     // Project some 3D points in the Color Frame
     if (!g_pProjHelper)
     {


### PR DESCRIPTION
...cording to http://wiki.ros.org/hydro/Migration#PCL

I got the error below. This PR will suppress the error.

/home/****_/catkin_ws/src/softkinetic/softkinetic_camera/src/softkinetic_start.cpp: function ‘void onNewDepthSample(DepthSense::DepthNode, DepthSense::DepthNode::NewSampleReceivedData)’ :
/home/**_**/catkin_ws/src/softkinetic/softkinetic_camera/src/softkinetic_start.cpp:173:41: error: cannot convert ‘ros::Time’ to ‘uint64_t {aka long unsigned int}’ in assignment
