### PR TITLE
Remove a harmless warning when compiling

### DIFF
--- a/softkinetic/package.xml
+++ b/softkinetic/package.xml
@@ -12,7 +12,7 @@
   <url type="website">http://wiki.ros.org/softkinetic</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>softkinetic_camera</build_depend>
+
   <run_depend>softkinetic_camera</run_depend>
 
 


### PR DESCRIPTION
and also when running: metapackages should not contain build dependencies.
