### PR TITLE
Add params to enable/disable color and depth streams

### DIFF
--- a/softkinetic_camera/launch/softkinetic_camera_ds311.launch
+++ b/softkinetic_camera/launch/softkinetic_camera_ds311.launch
@@ -4,6 +4,8 @@ Demo launch file to run single softkinetic camera in stand alone (no other /tf) 
 The arguments given are the device indices of the cameras determined by the DepthSense deamon.
 -->
 <launch>
+  <arg name="depth" default="true" />
+  <arg name="color" default="true" />
   <node name="softkinetic_camera" pkg="softkinetic_camera" type="softkinetic_bringup_node" args="0" output="screen" >
     <param name="camera_link"           type="string"    value="base_rgbd_camera_link" />
     <param name="confidence_threshold"  type="int"       value="200"   />
@@ -18,10 +20,12 @@ The arguments given are the device indices of the cameras determined by the Dept
     <param name="search_radius"         type="double"    value="0.05"  />
     <param name="minNeighboursInRadius" type="int"       value="50"    />
 
+    <param name="enable_depth"          type="bool"      value="$(arg depth)"  />
     <param name="depth_mode"            type="string"    value="long"  /> <!-- close or long -->
     <param name="depth_frame_format"    type="string"    value="QQVGA" /> <!-- QQVGA -->
     <param name="depth_frame_rate"      type="int"       value="30"    /> <!-- 25, 30, 50, 60 -->
 
+    <param name="enable_color"          type="bool"      value="$(arg color)"  />
     <param name="color_compression"     type="string"    value="YUY2"  /> <!-- YUY2 -->
     <param name="color_frame_format"    type="string"    value="VGA"   /> <!-- VGA -->
     <param name="color_frame_rate"      type="int"       value="30"    /> <!-- 30 -->

--- a/softkinetic_camera/launch/softkinetic_camera_ds325.launch
+++ b/softkinetic_camera/launch/softkinetic_camera_ds325.launch
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+Demo launch file to run single softkinetic camera in stand alone (no other /tf) setup with Rviz
+The arguments given are the device indices of the cameras determined by the DepthSense deamon.
+-->
+<launch>
+  <arg name="depth" default="true" />
+  <arg name="color" default="true" />
+  <node name="softkinetic_camera" pkg="softkinetic_camera" type="softkinetic_bringup_node" args="0" output="screen" >
+    <param name="camera_link"           type="string"    value="base_rgbd_camera_link" />
+    <param name="confidence_threshold"  type="int"       value="200"   />
+
+    <!-- Downsampling (using PCL voxel grid filter) -->
+    <param name="use_voxel_grid_filter" type="bool"      value="false"  />
+    <param name="voxel_grid_side"       type="double"    value="0.03"  />
+
+    <!-- Outlier removal (using PCL radius outlier removal filter) -->
+    <!-- Note that this is applied on the output of the downsampling filter! -->
+    <param name="use_radius_filter"     type="bool"      value="false" />
+    <param name="search_radius"         type="double"    value="0.05"  />
+    <param name="minNeighboursInRadius" type="int"       value="50"    />
+
+    <param name="enable_depth"          type="bool"      value="$(arg depth)"  />
+    <param name="depth_mode"            type="string"    value="close"  /> <!-- close or long -->
+    <param name="depth_frame_format"    type="string"    value="QVGA" /> <!-- QQVGA, QVGA, VGA -->
+    <param name="depth_frame_rate"      type="int"       value="25"    /> <!-- 25, 30 -->
+
+    <param name="enable_color"          type="bool"      value="$(arg color)"  />
+    <param name="color_compression"     type="string"    value="MJPEG"  /> <!-- YUY2, MJPEG -->
+    <param name="color_frame_format"    type="string"    value="WXGA"   /> <!-- QQVGA, QVGA, VGA, WXGA, NHD -->
+    <param name="color_frame_rate"      type="int"       value="25"    /> <!-- 25, 30 -->
+  </node>
+</launch>

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -123,10 +123,12 @@ int minNeighboursInRadius;
 /* shutdown request*/
 bool ros_node_shutdown = false;
 /* depth sensor parameters */
+bool _depth_enabled;
 DepthSense::DepthNode::CameraMode depth_mode;
 DepthSense::FrameFormat depth_frame_format;
 int depth_frame_rate;
 /* color sensor parameters */
+bool _color_enabled;
 DepthSense::CompressionType color_compression;
 DepthSense::FrameFormat color_frame_format;
 int color_frame_rate;
@@ -463,14 +465,14 @@ void configureColorNode()
 /*----------------------------------------------------------------------------*/
 void configureNode(Node node)
 {
-    if ((node.is<DepthNode>())&&(!g_dnode.isSet()))
+  if ((node.is<DepthNode>())&&(!g_dnode.isSet())&&(_depth_enabled))
     {
         g_dnode = node.as<DepthNode>();
         configureDepthNode();
         g_context.registerNode(node);
     }
 
-    if ((node.is<ColorNode>())&&(!g_cnode.isSet()))
+    if ((node.is<ColorNode>())&&(!g_cnode.isSet())&&(_color_enabled))
     {
         g_cnode = node.as<ColorNode>();
         configureColorNode();
@@ -574,6 +576,7 @@ int main(int argc, char* argv[])
         nh.param<int>("minNeighboursInRadius", minNeighboursInRadius, 0);
     };
 
+    nh.param<bool>("enable_depth", _depth_enabled, true);
     std::string depth_mode_str;
     nh.param<std::string>("depth_mode", depth_mode_str, "close");
     if ( depth_mode_str == "long" )
@@ -592,6 +595,7 @@ int main(int argc, char* argv[])
 
     nh.param<int>("depth_frame_rate", depth_frame_rate, 25);
 
+    nh.param<bool>("enable_color", _color_enabled, true);
     std::string color_compression_str;
     nh.param<std::string>("color_compression", color_compression_str, "MJPEG");
     if ( color_compression_str == "YUY2" )

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -465,7 +465,7 @@ void configureColorNode()
 /*----------------------------------------------------------------------------*/
 void configureNode(Node node)
 {
-  if ((node.is<DepthNode>())&&(!g_dnode.isSet())&&(_depth_enabled))
+    if ((node.is<DepthNode>())&&(!g_dnode.isSet())&&(_depth_enabled))
     {
         g_dnode = node.as<DepthNode>();
         configureDepthNode();


### PR DESCRIPTION
In some computers the USB port has not enough bandwidth to transmit both the color and depth streams. This parameters provide a convenient way to disable one of the streams when it is not needed by the user.
