### PR TITLE
Issue #28 improvement, but not full solution

### DIFF
--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -326,8 +326,6 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
 
     pub_cloud.publish (cloud);
     pub_depth.publish (depth_img_msg);
-
-    g_context.quit();
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
Surprisingly enough, remove the g_context.quit(); at the bottom of onNewDepthSample increase operation rate in some herzs, at least on my computer. **BUT** now the driver always escalates to SIGTERM when killing. Please give a try to confirm the improvement and hopefully find a solution to the SIGTERM killing.

But it's still too low.
