### PR TITLE
drops outdated opencv2 dependency for indigo

### DIFF
--- a/softkinetic_camera/package.xml
+++ b/softkinetic_camera/package.xml
@@ -16,7 +16,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>opencv2</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>message_generation</build_depend>
@@ -24,7 +23,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>opencv2</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
There is no `opencv2` any more in Indigo. Dropping it is safe, since `cv_bridge` is pulling in the required dependency. For details please refer to: https://github.com/ros/rosdistro/issues/4722
