### PR TITLE
Replicate kinect tf scheme.

### DIFF
--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -356,17 +356,18 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
   {
     for (int j = 0; j < img_depth.width; j++)
     {
+      // Convert softkinetic vertices into a kinect-like coordinates pointcloud
       count++;
-      current_cloud->points[count].x = -data.verticesFloatingPoint[count].x;
-      current_cloud->points[count].y =  data.verticesFloatingPoint[count].y;
       if (data.verticesFloatingPoint[count].z == 32001)
       {
-        current_cloud->points[count].z = 0;
+        current_cloud->points[count].x = 0;
       }
       else
       {
-        current_cloud->points[count].z = data.verticesFloatingPoint[count].z;
+        current_cloud->points[count].x = data.verticesFloatingPoint[count].z;
       }
+      current_cloud->points[count].y = - data.verticesFloatingPoint[count].x;
+      current_cloud->points[count].z =   data.verticesFloatingPoint[count].y;
 
       // Saturated pixels on depthMapFloatingPoint have -1 value, but on openni are NaN
       if (data.depthMapFloatingPoint[count] < 0.0)

--- a/softkinetic_camera/urdf/senz3d.urdf.xacro
+++ b/softkinetic_camera/urdf/senz3d.urdf.xacro
@@ -13,27 +13,27 @@
     </joint>
     <link name="${name}_link">
       <visual>
-        <origin xyz="-0.01 0 0" rpy="${-M_PI/2} -${M_PI} ${-M_PI/2}"/>
+        <origin xyz="-0.01 0.0 0.0" rpy="${-M_PI/2} -${M_PI} ${-M_PI/2}"/>
         <geometry>
           <!-- As we don't have a Senz3D mesh, use a deformed Asus Xtion Pro instead -->
           <mesh filename="package://softkinetic_camera/meshes/asus_xtion_pro_live.dae" scale="0.0006 0.0015 0.001"/>
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 -0.005" rpy="0 0 0"/>
+        <origin xyz="-0.01 0.0 0.0" rpy="0 0 0"/>
         <geometry>
-        <box size="0.11 0.04 0.04"/>
+        <box size="0.04 0.11 0.04"/>
       </geometry>
       </collision>
       <inertial>
         <mass value="0.271"/>
         <origin xyz="0 0 0"/>
-        <inertia ixx="0.001" ixy="0.0" ixz="0.0"
-                 iyy="0.001" iyz="0.0"
-                 izz="0.001"/>
+        <inertia ixx="0.000309392" ixy="0.0" ixz="0.0"
+                 iyy="0.000072267" iyz="0.0"
+                 izz="0.000309392"/>
       </inertial>
     </link>
-    
+
     <!-- Add frames for RGB and depth optical axes -->
     <joint name="${name}_rgb_joint" type="fixed">
       <origin xyz="0.0 0.0125 0.0" rpy="0.0 0.0 0.0"/>

--- a/softkinetic_camera/urdf/senz3d.urdf.xacro
+++ b/softkinetic_camera/urdf/senz3d.urdf.xacro
@@ -6,59 +6,59 @@
   <xacro:property name="M_PI" value="3.14159265359"/>
 
   <xacro:macro name="sensor_senz3d" params="parent name *origin">
-	<joint name="${name}_joint" type="fixed">
+    <joint name="${name}_joint" type="fixed">
       <insert_block name="origin"/>
       <parent link="${parent}"/>
-	  <child link="${name}_link"/>
-	</joint>
-	<link name="${name}_link">
-	  <visual>
-	    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
-	    <geometry>
-	      <!-- As we don't have a Senz3D mesh, use a deformed Asus Xtion Pro instead -->
-	      <mesh filename="package://softkinetic_camera/meshes/asus_xtion_pro_live.dae" scale="0.0006 0.0015 0.001"/>
-	    </geometry>
-	  </visual>
-	  <collision>
-	    <origin xyz="0.0 0.0 -0.005" rpy="0 0 0"/>
-	    <geometry>
-	    <box size="0.11 0.04 0.04"/>
-	  </geometry>
-	  </collision>
-	  <inertial>
-	    <mass value="0.271"/>
-	    <origin xyz="0 0 0"/>
-	    <inertia ixx="0.001" ixy="0.0" ixz="0.0"
-	      iyy="0.001" iyz="0.0"
-	      izz="0.001"/>
-	  </inertial>
-	</link>
-	
-	<!-- Add frames for RGB and depth optical axes -->
-	<joint name="${name}_rgb_joint" type="fixed">
-	  <origin xyz="0.0125 0.0 0.0" rpy="0.0 0.0 0.0"/>
-	  <parent link="${name}_link"/>
-	  <child link="${name}_rgb_frame"/>
-	</joint>
-	<link name="${name}_rgb_frame"/>
-	<joint name="${name}_rgb_optical_joint" type="fixed">
-	  <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 ${M_PI}" />
-	  <parent link="${name}_rgb_frame"/>
-	  <child link="${name}_rgb_optical_frame"/>
-	</joint>
-	<link name="${name}_rgb_optical_frame"/>
-	
-	<joint name="${name}_depth_joint" type="fixed">
-	  <origin xyz="-0.0125 0.0 0.0" rpy="0.0 0.0 0.0"/>
-	  <parent link="${name}_link"/>
-	  <child link="${name}_depth_frame"/>
-	</joint>
-	<link name="${name}_depth_frame"/>
-	<joint name="${name}_depth_optical_joint" type="fixed">
-	  <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 ${M_PI}" />
-	  <parent link="${name}_depth_frame"/>
-	  <child link="${name}_depth_optical_frame"/>
-	</joint>
-	<link name="${name}_depth_optical_frame"/>
+      <child link="${name}_link"/>
+    </joint>
+    <link name="${name}_link">
+      <visual>
+        <origin xyz="-0.01 0 0" rpy="${-M_PI/2} -${M_PI} ${-M_PI/2}"/>
+        <geometry>
+          <!-- As we don't have a Senz3D mesh, use a deformed Asus Xtion Pro instead -->
+          <mesh filename="package://softkinetic_camera/meshes/asus_xtion_pro_live.dae" scale="0.0006 0.0015 0.001"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.0 0.0 -0.005" rpy="0 0 0"/>
+        <geometry>
+        <box size="0.11 0.04 0.04"/>
+      </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.271"/>
+        <origin xyz="0 0 0"/>
+        <inertia ixx="0.001" ixy="0.0" ixz="0.0"
+                 iyy="0.001" iyz="0.0"
+                 izz="0.001"/>
+      </inertial>
+    </link>
+    
+    <!-- Add frames for RGB and depth optical axes -->
+    <joint name="${name}_rgb_joint" type="fixed">
+      <origin xyz="0.0 0.0125 0.0" rpy="0.0 0.0 0.0"/>
+      <parent link="${name}_link"/>
+      <child link="${name}_rgb_frame"/>
+    </joint>
+    <link name="${name}_rgb_frame"/>
+    <joint name="${name}_rgb_optical_joint" type="fixed">
+      <origin xyz="0.0 0.0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}"/>
+      <parent link="${name}_rgb_frame"/>
+      <child link="${name}_rgb_optical_frame"/>
+    </joint>
+    <link name="${name}_rgb_optical_frame"/>
+    
+    <joint name="${name}_depth_joint" type="fixed">
+      <origin xyz="0.0 -0.0125 0.0" rpy="0.0 0.0 0.0"/>
+      <parent link="${name}_link"/>
+      <child link="${name}_depth_frame"/>
+    </joint>
+    <link name="${name}_depth_frame"/>
+    <joint name="${name}_depth_optical_joint" type="fixed">
+      <origin xyz="0.0 0.0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}"/>
+      <parent link="${name}_depth_frame"/>
+      <child link="${name}_depth_optical_frame"/>
+    </joint>
+    <link name="${name}_depth_optical_frame"/>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This necessarily implies converting softkinetic vertices into a kinect-like coordinates pointcloud.

The need of this change came when simulating the Senz3D on Gazebo: the pointcloud appeared rotated, as Gazebo generates pointclouds following kinect frames.

Be warned that you must change your parent camera_link to something similar to the kinect one, that is, x-axis pointing forward and z pointing up. Apart from this, you should not notice the change but on visualizing the tf tree, as the optical frames remain the same.
