### PR TITLE
Add serial number parameters

### DIFF
--- a/softkinetic_camera/cfg/Softkinetic.cfg
+++ b/softkinetic_camera/cfg/Softkinetic.cfg
@@ -32,6 +32,9 @@ gen.add("vfov", double_t, 0, "Vertical FOV (degrees)", 90.0, 0.0, 180.0)
 gen.add("near_plane", double_t, 0, "Near plane", 0.01, 0.0, 1.0)
 gen.add("far_plane", double_t, 0, "Far plane", 10.0, 0.0, 10.0)
 
+# Serial identification
+gen.add("use_serial", bool_t, 0, "Enable serial number identification", False)
+
 # Modes
 mode_close = gen.const("close", str_t, "close", "Close mode")
 mode_long = gen.const("long", str_t, "long", "Long mode")

--- a/softkinetic_camera/launch/softkinetic_camera_demo.launch
+++ b/softkinetic_camera/launch/softkinetic_camera_demo.launch
@@ -11,6 +11,7 @@ The arguments given are the device indices of the cameras determined by the Dept
     <param name="rgb_calibration_file" type="string" value="$(find softkinetic_camera)/resources/senz3d.yaml" />
     <param name="confidence_threshold" type="int" value="200" />
     <param name="use_radius_outlier_filter" type="bool" value="false" />
+    <param name="use_serial" type="bool" value="false" />
     <param name="search_radius" type="double" value="0.05" />
     <param name="min_neighbours" type="int" value="50" />
 
@@ -27,5 +28,5 @@ The arguments given are the device indices of the cameras determined by the Dept
 
   <node pkg="rviz" type="rviz" name="softkinect_rviz" respawn="false"  required="true"
 	args="-d $(find softkinetic_camera)/launch/softkinetic.rviz"  />
-  
+
 </launch>

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -169,6 +169,10 @@ DepthSense::CompressionType color_compression;
 DepthSense::FrameFormat color_frame_format;
 int color_frame_rate;
 
+/* Serial Number parameters */
+bool use_serial;
+std::string serial;
+
 DepthSense::DepthNode::CameraMode depthMode(const std::string& depth_mode_str)
 {
     if ( depth_mode_str == "long" )
@@ -1016,6 +1020,33 @@ int main(int argc, char* argv[])
     {
       device_index = atoi(argv[1]);
     }
+    else
+    {
+      nh.param<bool>("use_serial", use_serial, false);
+      if (use_serial)
+      {
+        nh.getParam("serial", serial);
+        bool serialDeviceFound = false;
+        for (int i=0; i < da.size(); i++)
+        {
+          if (!da[i].getSerialNumber().compare(serial))
+          {
+            device_index = i;
+            serialDeviceFound = true;
+          }
+        }
+        if (serialDeviceFound)
+        {
+          ROS_INFO_STREAM("Serial number device found");
+        }
+        else
+        {
+          ROS_ERROR_STREAM("Serial number device not found !!");
+          ROS_ERROR_STREAM("Required Serial Number: " << serial);
+        }
+      }
+    }
+    ROS_INFO_STREAM("Serial Number: " << da[device_index].getSerialNumber());
 
     g_bDeviceFound = true;
 


### PR DESCRIPTION
For using multiple softkinetic devices on 1 computer, I added serial number parameters to identify devices.
When `use_serial` is `true`, you can select device by serial number.
Otherwise, it's is same as before.
