### PR TITLE
Fix use_filter default value True -> False

### DIFF
--- a/softkinetic_camera/cfg/Softkinetic.cfg
+++ b/softkinetic_camera/cfg/Softkinetic.cfg
@@ -12,7 +12,7 @@ gen.add("camera_link", str_t, 0, "Camera optical frame", "base_rgbd_camera_optic
 gen.add("confidence_threshold", int_t, 0, "Confidence threshold", 200, 0, 2000)
 
 # Downsampling (using PCL voxel grid filter)
-gen.add("use_voxel_grid_filter", bool_t, 0, "Enable downsampling (voxel grid) filter", True)
+gen.add("use_voxel_grid_filter", bool_t, 0, "Enable downsampling (voxel grid) filter", False)
 gen.add("voxel_grid_size", double_t, 0, "Voxel grid size", 0.01, 0.0, 0.1)
 
 # Outlier removal (using PCL radius outlier removal filter)
@@ -21,7 +21,7 @@ gen.add("search_radius", double_t, 0, "Search radius", 0.05, 0.0, 0.1)
 gen.add("min_neighbours", int_t, 0, "Minimum number of neightbours within the search radius", 50, 1, 500)
 
 # PassThrough filter
-gen.add("use_passthrough_filter", bool_t, 0, "Enable passthrough filter", True)
+gen.add("use_passthrough_filter", bool_t, 0, "Enable passthrough filter", False)
 gen.add("limit_min", double_t, 0, "Limit minimum value", 0.01, 0.0, 1.0)
 gen.add("limit_max", double_t, 0, "Limit maximum value", 10.0, 0.0, 10.0)
 


### PR DESCRIPTION
Default value of `use_voxel_grid_filter` and `use_passthrough_filter` was `True`, but it should be `False` according to https://github.com/ipa320/softkinetic/blob/indigo_dev/softkinetic_camera/src/softkinetic_start.cpp#L871 and https://github.com/ipa320/softkinetic/blob/indigo_dev/softkinetic_camera/src/softkinetic_start.cpp#L898
