### PR TITLE
add time stamp in PointCloud ROS msg

### DIFF
--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -537,6 +537,7 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
   pcl::toROSMsg(*current_cloud, cloud);
 
   img_depth.header.stamp = ros::Time::now();
+  cloud.header.stamp = ros::Time::now();
   depth_info.header      = img_depth.header;
 
   pub_cloud.publish(cloud);


### PR DESCRIPTION
now point cloud header does not have time stamp.
it may cause problems i.e. message_filter
