### PR TITLE
Point cloud reformation to kinect-like 

### DIFF
--- a/softkinetic_camera/launch/softkinetic_camera_demo.launch
+++ b/softkinetic_camera/launch/softkinetic_camera_demo.launch
@@ -19,12 +19,12 @@ The arguments given are the device indices of the cameras determined by the Dept
     <param name="depth_frame_format" value="QVGA" /> <!-- ignored -->
     <param name="depth_frame_rate" value="25" /> <!-- 25, 30, 50, 60 -->
     <param name="color_compression" value="MJPEG" /> <!-- YUY2, MJPEG -->
-    <param name="color_frame_format" value="WXGA_H" /> <!-- QQVGA, QVGA, VGA, WXGA_H, NHD -->
+    <param name="color_frame_format" value="VGA" /> <!-- QQVGA, QVGA, VGA, WXGA_H, NHD -->
     <param name="color_frame_rate" value="25" /> <!-- 25, 30 -->
   </node>
 
   <node pkg="tf" type="static_transform_publisher" name="softkinect_tf"
-        args="0 0 0 0 0 1.2 /base /softkinetic_camera_link 40" />
+        args="0 0 0 0 0 0 /base /softkinetic_camera_rgb_optical_frame 40" />
 
   <node pkg="rviz" type="rviz" name="softkinect_rviz" respawn="false"  required="true"
 	args="-d $(find softkinetic_camera)/launch/softkinetic.rviz"  />

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -478,11 +478,6 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
       continue;
     }
 
-    // Convert softkinetic vertices into a kinect-like coordinates pointcloud
-    current_cloud->points[count].x =   data.verticesFloatingPoint[count].x + 0.025;
-    current_cloud->points[count].y = - data.verticesFloatingPoint[count].y;
-    current_cloud->points[count].z =   data.verticesFloatingPoint[count].z;
-
     // Get mapping between depth map and color map, assuming we have a RGB image
     if (img_rgb.data.size() == 0)
     {
@@ -500,6 +495,14 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
       current_cloud->points[count].g = cv_img_rgb.at<cv::Vec3b>(y_pos, x_pos)[1];
       current_cloud->points[count].r = cv_img_rgb.at<cv::Vec3b>(y_pos, x_pos)[2];
     }
+    else
+    {
+      continue;
+    }
+    // Convert softkinetic vertices into a kinect-like coordinates pointcloud
+    current_cloud->points[count].x =   data.verticesFloatingPoint[count].x + 0.025;
+    current_cloud->points[count].y = - data.verticesFloatingPoint[count].y;
+    current_cloud->points[count].z =   data.verticesFloatingPoint[count].z;
   }
 
   // Check for usage of voxel grid filtering to downsample point cloud

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -479,9 +479,9 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
     }
 
     // Convert softkinetic vertices into a kinect-like coordinates pointcloud
-    current_cloud->points[count].x =   data.verticesFloatingPoint[count].z;
-    current_cloud->points[count].y = - data.verticesFloatingPoint[count].x;
-    current_cloud->points[count].z =   data.verticesFloatingPoint[count].y;
+    current_cloud->points[count].x =   data.verticesFloatingPoint[count].x + 0.025;
+    current_cloud->points[count].y = - data.verticesFloatingPoint[count].y;
+    current_cloud->points[count].z =   data.verticesFloatingPoint[count].z;
 
     // Get mapping between depth map and color map, assuming we have a RGB image
     if (img_rgb.data.size() == 0)
@@ -841,20 +841,18 @@ int main(int argc, char* argv[])
   signal(SIGINT, sigintHandler);
 
   // Get frame id from parameter server
-  std::string softkinetic_link;
   if (!nh.hasParam("camera_link"))
   {
     ROS_ERROR_STREAM("For " << ros::this_node::getName() << ", parameter 'camera_link' is missing.");
     ros_node_shutdown = true;
   }
 
-  nh.param<std::string>("camera_link", softkinetic_link, "softkinetic_link");
-  cloud.header.frame_id = softkinetic_link;
 
   // Fill in the color and depth images message header frame id
   std::string optical_frame;
   if (nh.getParam("rgb_optical_frame", optical_frame))
   {
+    cloud.header.frame_id = optical_frame.c_str();
     img_rgb.header.frame_id = optical_frame.c_str();
     img_mono.header.frame_id = optical_frame.c_str();
   }


### PR DESCRIPTION
Point Cloud reformation to kinect-like
- optical frame coordinates are modified to kinect-like 
- point cloud frame modified to `softkinetic_camera_rgb_optical_frame`, same as rgb camera frame
- remove non-colorized point cloud

The reason why I removed non-colorized point cloud is that point  cloud which contain both colorized and non-colorized points is too complicated to manage.
When you use same point cloud processing as kinect or other devices, point cloud which consist of only colorized points is easy to manage and have no necessity to modify algorithm.
