### PR TITLE
compile dummy node if the depthsense sdk is not found

### DIFF
--- a/softkinetic_camera/CMakeLists.txt
+++ b/softkinetic_camera/CMakeLists.txt
@@ -16,14 +16,6 @@ find_package(catkin REQUIRED
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(DepthSenseSDK)
 
-if(NOT DepthSenseSDK_FOUND)
-  message(FATAL_ERROR "+++++++++ Could not locate the DepthSense SDK +++++++++
-Please install the SDK before trying to build the 'softkinetic_camera' package, see README.txt.
-
-Cannot continue, aborting.")
-  return()
-endif()
-
 generate_dynamic_reconfigure_options(cfg/Softkinetic.cfg)
 
 ###################################
@@ -33,18 +25,39 @@ catkin_package(
   CATKIN_DEPENDS roscpp std_msgs pcl_ros cv_bridge image_transport camera_info_manager message_runtime dynamic_reconfigure
 )
 
+
 ###########
 ## Build ##
 ###########
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${DepthSenseSDK_INCLUDE_DIRS}
-)
 
-add_executable(softkinetic_bringup_node src/softkinetic_start.cpp)
-add_dependencies(softkinetic_bringup_node ${PROJECT_NAME}_gencfg)
-target_link_libraries(softkinetic_bringup_node ${DepthSenseSDK_LIBRARIES} ${catkin_LIBRARIES})
+if(NOT DepthSenseSDK_FOUND)
+  message(WARNING "+++++++++++++++++++++++++++++++++++++++++++++++++++++++
++++++++++ Could not locate the DepthSense SDK +++++++++
+Please install the SDK before trying to build the 'softkinetic_camera' package, see README.txt.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
+
+  include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+  )
+
+  add_executable(softkinetic_bringup_node src/softkinetic_dummy.cpp)
+  add_dependencies(softkinetic_bringup_node ${PROJECT_NAME}_gencfg)
+  target_link_libraries(softkinetic_bringup_node ${catkin_LIBRARIES})
+
+else()
+
+  include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+    ${DepthSenseSDK_INCLUDE_DIRS}
+  )
+
+  add_executable(softkinetic_bringup_node src/softkinetic_start.cpp)
+  add_dependencies(softkinetic_bringup_node ${PROJECT_NAME}_gencfg)
+  target_link_libraries(softkinetic_bringup_node ${DepthSenseSDK_LIBRARIES} ${catkin_LIBRARIES})
+
+endif()
 
 install(TARGETS softkinetic_bringup_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/softkinetic_camera/src/softkinetic_dummy.cpp
+++ b/softkinetic_camera/src/softkinetic_dummy.cpp
@@ -1,0 +1,22 @@
+#include <ros/ros.h>
+
+int main(int argc, char* argv[])
+{
+  // Initialize ROS
+  ros::init(argc, argv, "softkinetic_bringup_node");
+  ros::NodeHandle nh;
+
+  ros::Rate r(0.1);
+  while(ros::ok())
+  {
+    ROS_ERROR(
+      "\n++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+      "\n++++++++++++ Could not locate the DepthSense SDK +++++++++++"
+      "\nPlease install the SDK, create an softkinectic overlay"
+      "\nand recompile the softkinetic_camera package, see README.txt."
+      "\n++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+
+    r.sleep();
+  }
+  return 0;
+}


### PR DESCRIPTION
necessary for successful travis build
reason: the depthsense sdk can not be downloaded without a registered account
