### PR TITLE
use kinect-like frame settings

### DIFF
--- a/softkinetic_camera/launch/softkinetic.rviz
+++ b/softkinetic_camera/launch/softkinetic.rviz
@@ -5,7 +5,7 @@ Panels:
     Property Tree Widget:
       Expanded: ~
       Splitter Ratio: 0.5
-    Tree Height: 706
+    Tree Height: 441
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -69,7 +69,7 @@ Visualization Manager:
       Queue Size: 10
       Selectable: true
       Size (Pixels): 3
-      Size (m): 0.01
+      Size (m): 0.001
       Style: Flat Squares
       Topic: /softkinetic_camera/depth/points
       Use Fixed Frame: true
@@ -108,6 +108,58 @@ Visualization Manager:
       Queue Size: 2
       Transport Hint: raw
       Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base:
+          Value: true
+        softkinetic_camera_depth_frame:
+          Value: true
+        softkinetic_camera_depth_optical_frame:
+          Value: true
+        softkinetic_camera_link:
+          Value: true
+        softkinetic_camera_rgb_frame:
+          Value: true
+        softkinetic_camera_rgb_optical_frame:
+          Value: true
+      Marker Scale: 0.3
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        base:
+          softkinetic_camera_link:
+            softkinetic_camera_depth_frame:
+              softkinetic_camera_depth_optical_frame:
+                {}
+            softkinetic_camera_rgb_frame:
+              softkinetic_camera_rgb_optical_frame:
+                {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz/Camera
+      Enabled: true
+      Image Rendering: background and overlay
+      Image Topic: /softkinetic_camera/rgb/image_color
+      Name: Camera
+      Overlay Alpha: 0.5
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+      Visibility:
+        Color Image: true
+        Depth Image: true
+        Grid: true
+        Mono Image: true
+        PointCloud2: true
+        TF: true
+        Value: true
+      Zoom Factor: 1
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -132,7 +184,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 2.56689
+      Distance: 0.690821
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.06
         Stereo Focal Distance: 1
@@ -144,12 +196,14 @@ Visualization Manager:
         Z: 0
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 0.585398
+      Pitch: 0.335398
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 1.2404
+      Yaw: 3.7354
     Saved: ~
 Window Geometry:
+  Camera:
+    collapsed: false
   Color Image:
     collapsed: false
   Depth Image:

--- a/softkinetic_camera/launch/softkinetic_camera_demo.launch
+++ b/softkinetic_camera/launch/softkinetic_camera_demo.launch
@@ -23,8 +23,18 @@ The arguments given are the device indices of the cameras determined by the Dept
     <param name="color_frame_rate" value="25" /> <!-- 25, 30 -->
   </node>
 
+  <arg name="pi/2" value="1.5707963267948966" />
+  <arg name="optical_rotate" value="0 0 0 -$(arg pi/2) 0 -$(arg pi/2)" />
   <node pkg="tf" type="static_transform_publisher" name="softkinect_tf"
-        args="0 0 0 0 0 1.2 /base /softkinetic_camera_link 40" />
+        args="0 0 0 0 0 0 /base /softkinetic_camera_link 40" />
+  <node pkg="tf" type="static_transform_publisher" name="softkinect_rgb_frame_tf"
+        args="0 0.00090 0  0 0 0 /softkinetic_camera_link /softkinetic_camera_rgb_frame 40" />
+  <node pkg="tf" type="static_transform_publisher" name="softkinect_rgb_optical_tf"
+        args="$(arg optical_rotate) /softkinetic_camera_rgb_frame /softkinetic_camera_rgb_optical_frame 40" />
+  <node pkg="tf" type="static_transform_publisher" name="softkinect_depth_frame_tf"
+        args="0 -0.0090 0.005 0 0 0 /softkinetic_camera_link /softkinetic_camera_depth_frame 40" />
+  <node pkg="tf" type="static_transform_publisher" name="softkinect_depth_optical_tf"
+        args="$(arg optical_rotate) /softkinetic_camera_depth_frame /softkinetic_camera_depth_optical_frame 40" />
 
   <node pkg="rviz" type="rviz" name="softkinect_rviz" respawn="false"  required="true"
 	args="-d $(find softkinetic_camera)/launch/softkinetic.rviz"  />

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -840,17 +840,6 @@ int main(int argc, char* argv[])
   // Override the default ROS SIGINT handler to call g_context.quit() and avoid escalating to SIGTERM
   signal(SIGINT, sigintHandler);
 
-  // Get frame id from parameter server
-  std::string softkinetic_link;
-  if (!nh.hasParam("camera_link"))
-  {
-    ROS_ERROR_STREAM("For " << ros::this_node::getName() << ", parameter 'camera_link' is missing.");
-    ros_node_shutdown = true;
-  }
-
-  nh.param<std::string>("camera_link", softkinetic_link, "softkinetic_link");
-  cloud.header.frame_id = softkinetic_link;
-
   // Fill in the color and depth images message header frame id
   std::string optical_frame;
   if (nh.getParam("rgb_optical_frame", optical_frame))
@@ -867,10 +856,12 @@ int main(int argc, char* argv[])
   if (nh.getParam("depth_optical_frame", optical_frame))
   {
     img_depth.header.frame_id = optical_frame.c_str();
+    cloud.header.frame_id = optical_frame.c_str();
   }
   else
   {
     img_depth.header.frame_id = "/softkinetic_depth_optical_frame";
+    cloud.header.frame_id = "/softkinetic_depth_optical_frame";
   }
 
   // Get confidence threshold from parameter server

--- a/softkinetic_camera/src/softkinetic_start.cpp
+++ b/softkinetic_camera/src/softkinetic_start.cpp
@@ -479,9 +479,9 @@ void onNewDepthSample(DepthNode node, DepthNode::NewSampleReceivedData data)
     }
 
     // Convert softkinetic vertices into a kinect-like coordinates pointcloud
-    current_cloud->points[count].x =   data.verticesFloatingPoint[count].z;
-    current_cloud->points[count].y = - data.verticesFloatingPoint[count].x;
-    current_cloud->points[count].z =   data.verticesFloatingPoint[count].y;
+    current_cloud->points[count].x =   data.verticesFloatingPoint[count].x;
+    current_cloud->points[count].y = - data.verticesFloatingPoint[count].y;
+    current_cloud->points[count].z =   data.verticesFloatingPoint[count].z;
 
     // Get mapping between depth map and color map, assuming we have a RGB image
     if (img_rgb.data.size() == 0)


### PR DESCRIPTION
There are several atttempt to support 'kinect-like' settings, https://github.com/ipa320/softkinetic/pull/44, https://github.com/ipa320/softkinetic/pull/58

I think the definition of kinect-like consists of
- publish point cloud in 'depth frame'
- point cloud coordinates is : 'kinect-like' coordinates cloud means +z for forward +y is down and +x for right-ward
- use rgdb_launch/launch/kinect_frames.launch style to set camera_link to depth/rgb optical frame

Here is the examples from openni2.launch

![screenshot from 2016-06-09 14 21 18](https://cloud.githubusercontent.com/assets/493276/15925917/2e47193c-2e74-11e6-9f5d-f671e1c2acfb.png)
![screenshot from 2016-06-09 14 20 54](https://cloud.githubusercontent.com/assets/493276/15925925/3335d4a6-2e74-11e6-9941-758ebe98fbf2.png)
![screenshot from 2016-06-09 14 21 08](https://cloud.githubusercontent.com/assets/493276/15925926/359f6eaa-2e74-11e6-822c-94bdf6f43962.png)

https://github.com/ipa320/softkinetic/pull/63/commits/159419179d0312b40dba932c9bb3cd9d4963f7ad includes 

```
 +  <node pkg="tf" type="static_transform_publisher" name="softkinect_rgb_frame_tf"
 +        args="0 0.00090 0  0 0 0 /softkinetic_camera_link /softkinetic_camera_rgb_frame 40" />
 +  <node pkg="tf" type="static_transform_publisher" name="softkinect_depth_frame_tf"
 +        args="0 -0.0090 0.005 0 0 0 /softkinetic_camera_link /softkinetic_camera_depth_frame 40" />
```

which indicates the translation between rgb and depth frames is '0.00180 0 0.005' which may differ from the urdf settings (0.0250 displacement), I'm not sure if this parameter is general one, but at least for my camera, it improve the depth-camera registration

0.0250 displacement (see left bottom camera iamge which overay point cloud into camera image)
![screenshot from 2016-06-09 14 38 06](https://cloud.githubusercontent.com/assets/493276/15926014/a8d03800-2e74-11e6-9077-102eff033268.png)

0.00180 0 0.005 displacement
![screenshot from 2016-06-09 14 36 52](https://cloud.githubusercontent.com/assets/493276/15926026/c245d240-2e74-11e6-9a2e-28f594bda235.png)
- softkinetic.rviz : update rviz config for kinect-like frame settings
- softkinetic_camera_demo.launch : publish 'kinect_frame' like tf using static_tf_publihser, see rgdb_launch/launch/kinect_frames.launch, maybe we need to remove these frames from urdf?
- 'kinect-like' coordinates cloud means +z for forward +y is down and +x for right-ward
- use depth_optical_frame for cloud header
